### PR TITLE
smarkets/bcrypt version tag

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {lib_dirs, ["deps"]}.
 
 {deps, [{proper, "1.0", {git, "git://github.com/manopapad/proper.git", {branch, "master"}}},
-        {bcrypt, "0.4.1", {git, "git://github.com/smarkets/erlang-bcrypt.git", {branch, "master"}}}]}.
+        {bcrypt, "0.4.1", {git, "git://github.com/smarkets/erlang-bcrypt.git", {tag, "0.4.1"}}}]}.
 


### PR DESCRIPTION
Hey,

since bcrypt is now at 0.5.0, you will get

```
ERROR: Dependency dir /Users/adam/dev/mml_proxy/deps/bcrypt failed application validation with reason:
{version_mismatch,{"/Users/adam/dev/mml_proxy/deps/bcrypt/src/bcrypt.app.src",
                   {expected,"0.4.1"},
                   {has,"0.5.0"}}}.
```

This commit sticks erlpass to the 0.4.1 tag.
