### PR TITLE
Update proper for OTP 18.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.rebar/
 *.swp
 *.swo
 *.beam

--- a/rebar.test.config
+++ b/rebar.test.config
@@ -1,5 +1,5 @@
 {lib_dirs, ["deps"]}.
 
-{deps, [{proper, "1.1", {git, "https://github.com/manopapad/proper.git", {tag, "v1.1"}}},
+{deps, [{proper, "1.1", {git, "https://github.com/manopapad/proper.git", "20e62bc32f9bd43fe2ff52944a4ef99eb71d1399"}},
         {bcrypt, "0.5.*", {git, "https://github.com/opscode/erlang-bcrypt.git", {tag, "0.5.0.3"}}}]}.
 


### PR DESCRIPTION
Although proper has no new releases, the current version (in master) no longer uses type `dict()` which was removed from Erlang 18.0. I decided to use its SHA instead, until they generate a new release.