### PR TITLE
upgraded bcrypt dep for use with erlang versions >= 21.3

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,7 +11,7 @@ Call `rebar3 compile`.
 
 ## How do I use this ##
 
-This library application depends on bcrypt (which in turn depends on crypto). You thus need to call `application:start(crypto)` and `application:start(bcrypt)` before being able to call the `erlpass` functions. The module has these two applications in its dependencies and it should be safe to use in releases. The possible calls are:
+This library application depends on bcrypt (which in turn depends on crypto and poolboy). You thus need to call `application:start(crypto)`, `application:start(poolboy)`, and `application:start(bcrypt)` before being able to call the `erlpass` functions. The module has these three applications in its dependencies and it should be safe to use in releases. The possible calls are:
 
     1> 1> application:ensure_all_started(erlpass).
     {ok,[crypto, bcrypt,erlpass]}

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{deps, [{bcrypt, "1.0.2"}]}.
+{deps, [{bcrypt, "1.1.2"}]}.
 
 {eunit_opts, [{dir, "test"}]}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,8 @@
 {"1.1.0",
-[{<<"bcrypt">>,{pkg,<<"bcrypt">>,<<"1.0.2">>},0}]}.
+[{<<"bcrypt">>,{pkg,<<"bcrypt">>,<<"1.1.2">>},0},
+ {<<"poolboy">>,{pkg,<<"poolboy">>,<<"1.5.2">>},1}]}.
 [
 {pkg_hash,[
- {<<"bcrypt">>, <<"6735F66D3A7309AF166CE660161009B7D9B9216508B8B2E6A0A9090AF35CB757">>}]}
+ {<<"bcrypt">>, <<"36C9F72EEFDB7736EA27260B5FE2D8694D4AAC9E17361EE566E5D71173EA3CA7">>},
+ {<<"poolboy">>, <<"392B007A1693A64540CEAD79830443ABF5762F5D30CF50BC95CB2C1AAAFA006B">>}]}
 ].

--- a/test/erlpass_tests.erl
+++ b/test/erlpass_tests.erl
@@ -12,6 +12,7 @@
 %% EUNIT TESTS
 setup() ->
     application:start(crypto),
+    application:start(poolboy),
     application:start(bcrypt).
 
 good_default_work_factor_test_() ->


### PR DESCRIPTION
Hi -- 

[bcrypt 1.0 is not compatible](https://github.com/erlangpack/bcrypt#otp-compatibility) with recent (>= 21.3) Erlang releases.  This PR represents the changes necessary to upgrade to bcrypt 1.1.2.

(Thanks for the library, it's handy!)